### PR TITLE
v2 - 運用行路図に南古谷駅を追加する

### DIFF
--- a/src/app/pages/operation/operation-route-diagram/services/operation-route-diagram.service.ts
+++ b/src/app/pages/operation/operation-route-diagram/services/operation-route-diagram.service.ts
@@ -65,6 +65,7 @@ export class OperationRouteDiagramService {
             '武蔵浦和',
             '大宮',
             '指扇',
+            '南古谷',
             '川越',
         ];
 


### PR DESCRIPTION
2022/03/12改正から埼京線南古谷始発列車が登場したことに伴う対応(@soun2020さんからの報告による)