### PR TITLE
運用表から全線時刻表に遷移するリンクを踏むとフリーズする問題の修正

### DIFF
--- a/src/app/pages/operation/operation-table/components/operation-table-table-presentational/operation-table-table-presentational.component.html
+++ b/src/app/pages/operation/operation-table/components/operation-table-table-presentational/operation-table-table-presentational.component.html
@@ -165,7 +165,7 @@
                     '/timetable',
                     'all-line',
                     {
-                        calendar_id: calendar.id,
+                        calendar_id: calendar.calendarId,
                         trip_direction: tripOperationList.trip.tripDirection,
                         trip_block_id: tripOperationList.trip.tripBlockId
                     }


### PR DESCRIPTION
calendarIdがundefinedになっていた