### PR TITLE
運用行路図に元住吉駅と麻布十番駅を追加する

### DIFF
--- a/src/app/pages/operation/operation-route-diagram/states/operation-route-diagram.state.ts
+++ b/src/app/pages/operation/operation-route-diagram/states/operation-route-diagram.state.ts
@@ -136,6 +136,10 @@ const targetStations = [
     },
     {
         routeName: ['東横線', '目黒線'],
+        stationName: '元住吉',
+    },
+    {
+        routeName: ['東横線', '目黒線'],
         stationName: '武蔵小杉',
     },
     {
@@ -217,6 +221,10 @@ const targetStations = [
     {
         routeName: ['南北線', '三田線'],
         stationName: '白金高輪',
+    },
+    {
+        routeName: ['南北線'],
+        stationName: '麻布十番',
     },
     {
         routeName: ['南北線'],


### PR DESCRIPTION
https://github.com/kaito3desuyo/sotetsu-lab-v3-client/issues/94